### PR TITLE
AEM 6.6 deployment

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,6 @@
   ],
   "ignoreDeps": [
     "io.wcm.maven:io.wcm.maven.aem-dependencies",
-    "io.wcm:io.wcm.caconfig.extensions",
     "io.wcm.devops.conga.definitions.it:io.wcm.devops.conga.definitions.it.sample.parent",
     "io.wcm.devops.conga.definitions.it:io.wcm.devops.conga.definitions.it.sample.complete",
     "io.wcm.devops.conga.definitions.it:io.wcm.devops.conga.definitions.it.sample.core",

--- a/README.md
+++ b/README.md
@@ -36,6 +36,23 @@
   * Tenant 3 (no mapping): http://tenant3-no-mapping.aemdef-it-sample-65.localhost:55035/
 
 
+### Deploy and run local Dispatcher with AEM 6.6
+
+* Setup AEM 6.5 Author on port 45026, Publish on port 45036
+* Deploy application locally with `build-deploy-author-and-publish_aem66.sh`
+* Add local hosts:
+  ```
+  127.0.0.1 tenant1.aemdef-it-sample-66.localhost
+  127.0.0.1 tenant2.aemdef-it-sample-66.localhost
+  127.0.0.1 tenant3-no-mapping.aemdef-it-sample-65.localhost
+  ```
+* Start local dispatcher in docker with `config-definition/dispatcher-aem66-run-local.sh` script
+* Open website per tenant:
+  * Tenant 1: http://tenant1.aemdef-it-sample-66.localhost:55036/
+  * Tenant 2: http://tenant2.aemdef-it-sample-66.localhost:55036/
+  * Tenant 3 (no mapping): http://tenant3-no-mapping.aemdef-it-sample-66.localhost:55036/
+
+
 ---
 
 This is an AEM project set up with the [wcm.io Maven Archetype for AEM][wcmio-maven-archetype-aem].

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@
   ```
 * Start local dispatcher in docker with `config-definition/dispatcher-aem65-run-local.sh` script
 * Open website per tenant:
-  * Tenant 1: http://tenant1.aemdef-it-sample-65.localhost:55035/
-  * Tenant 2: http://tenant2.aemdef-it-sample-65.localhost:55035/
-  * Tenant 3 (no mapping): http://tenant3-no-mapping.aemdef-it-sample-65.localhost:55035/
+  * Tenant 1: http://tenant1.aemdef-it-sample-65.localhost:5505/
+  * Tenant 2: http://tenant2.aemdef-it-sample-65.localhost:5505/
+  * Tenant 3 (no mapping): http://tenant3-no-mapping.aemdef-it-sample-65.localhost:5505/
 
 
 ### Deploy and run local Dispatcher with AEM 6.6
@@ -48,9 +48,9 @@
   ```
 * Start local dispatcher in docker with `config-definition/dispatcher-aem66-run-local.sh` script
 * Open website per tenant:
-  * Tenant 1: http://tenant1.aemdef-it-sample-66.localhost:55036/
-  * Tenant 2: http://tenant2.aemdef-it-sample-66.localhost:55036/
-  * Tenant 3 (no mapping): http://tenant3-no-mapping.aemdef-it-sample-66.localhost:55036/
+  * Tenant 1: http://tenant1.aemdef-it-sample-66.localhost:5506/
+  * Tenant 2: http://tenant2.aemdef-it-sample-66.localhost:5506/
+  * Tenant 3 (no mapping): http://tenant3-no-mapping.aemdef-it-sample-66.localhost:5506/
 
 
 ---

--- a/build-deploy-author-and-publish_aem66.sh
+++ b/build-deploy-author-and-publish_aem66.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# #%L
+#  wcm.io
+#  %%
+#  Copyright (C) 2022 wcm.io
+#  %%
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#  #L%
+
+# Builds the application, deploys it to local author, and then deploys it to local publish as well (without building it again)
+# Deployment to author and publish runs in parallel
+
+# Display a pause message (only when the script was executed via double-click on windows)
+pause_message() {
+  if [ "$DISPLAY_PAUSE_MESSAGE_WRAPPER" = true ]; then
+    echo ""
+    read -n1 -r -p "Press any key to continue..."
+  fi
+}
+
+if [[ $0 == *":\\"* ]]; then
+  DISPLAY_PAUSE_MESSAGE_WRAPPER=true
+fi
+
+# Build application
+./build-deploy.sh build --maven.profiles=fast,aem66 --conga.environment=local-aem66 "$@"
+if [ "$?" -ne "0" ]; then
+  pause_message
+  exit $?
+fi
+
+# Deploy to author (in parallel)
+./build-deploy.sh deploy --maven.profiles=fast,aem66 --conga.node=aem-author --conga.environment=local-aem66 "$@" &
+
+# Deploy to publish (in parallel)
+./build-deploy.sh deploy --maven.profiles=fast,publish,aem66 --conga.node=aem-publish --conga.environment=local-aem66 "$@" &
+
+wait
+pause_message

--- a/build-deploy-publish_aem66.sh
+++ b/build-deploy-publish_aem66.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# #%L
+#  wcm.io
+#  %%
+#  Copyright (C) 2022 wcm.io
+#  %%
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#  #L%
+
+# Call with "help" parameter to display syntax information
+
+MAVEN_PROFILES="fast,publish,aem66"
+CONGA_NODE="aem-publish"
+CONGA_ENVIRONMENT="local-aem66"
+
+if [[ $0 == *":\\"* ]]; then
+  DISPLAY_PAUSE_MESSAGE=true
+fi
+
+./build-deploy.sh --maven.profiles=${MAVEN_PROFILES} --conga.node=${CONGA_NODE} --conga.environment=${CONGA_ENVIRONMENT} --display.pause.message=${DISPLAY_PAUSE_MESSAGE} "$@"

--- a/build-deploy_aem66.sh
+++ b/build-deploy_aem66.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# #%L
+#  wcm.io
+#  %%
+#  Copyright (C) 2022 wcm.io
+#  %%
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#  #L%
+
+MAVEN_PROFILES="fast,aem66"
+CONGA_ENVIRONMENT="local-aem66"
+
+if [[ $0 == *":\\"* ]]; then
+  DISPLAY_PAUSE_MESSAGE=true
+fi
+
+./build-deploy.sh --maven.profiles=${MAVEN_PROFILES} --conga.environment=${CONGA_ENVIRONMENT} --display.pause.message=${DISPLAY_PAUSE_MESSAGE} "$@"

--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -80,6 +80,22 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.caconfig.api</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.caconfig.spi</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.caconfig.impl</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/bundles/core/src/main/java/io/wcm/devops/conga/definitions/it/sample/components/CurrentDate.java
+++ b/bundles/core/src/main/java/io/wcm/devops/conga/definitions/it/sample/components/CurrentDate.java
@@ -21,6 +21,7 @@ public class CurrentDate {
   }
 
   /**
+   * Current year
    * @return Current year
    */
   public int getYear() {

--- a/bundles/core/src/main/java/io/wcm/devops/conga/definitions/it/sample/components/CustomCarousel.java
+++ b/bundles/core/src/main/java/io/wcm/devops/conga/definitions/it/sample/components/CustomCarousel.java
@@ -18,6 +18,7 @@ import io.wcm.handler.media.MediaHandler;
 
 /**
  * Model for the custom carousel component.
+ *
  * <p>
  * Please note: There is already is a pre-built "Carousel" Core Component which does basically the same
  * as this component with a much more sophisticated edit mode support. Use it, instead of this demo component!
@@ -68,14 +69,16 @@ public class CustomCarousel {
   }
 
   /**
-   * @return Unique ID of this component that can be used in HTML markup
+   * Unique ID of this component that can be used in HTML markup
+   * @return ID
    */
   public String getId() {
     return id;
   }
 
   /**
-   * @return List of images for each slide
+   * List of images for each slide
+   * @return Images
    */
   public List<Media> getSlideImages() {
     return Collections.unmodifiableList(this.slideImages);

--- a/bundles/core/src/main/java/io/wcm/devops/conga/definitions/it/sample/config/impl/LinkHandlerConfigImpl.java
+++ b/bundles/core/src/main/java/io/wcm/devops/conga/definitions/it/sample/config/impl/LinkHandlerConfigImpl.java
@@ -8,8 +8,8 @@ import org.jetbrains.annotations.Nullable;
 import org.osgi.service.component.annotations.Component;
 
 import com.day.cq.wcm.api.Page;
-import com.google.common.collect.ImmutableList;
 
+import io.wcm.devops.conga.definitions.it.sample.config.AppTemplate;
 import io.wcm.handler.link.spi.LinkHandlerConfig;
 import io.wcm.handler.link.spi.LinkType;
 import io.wcm.handler.link.type.ExternalLinkType;
@@ -18,15 +18,13 @@ import io.wcm.handler.link.type.InternalLinkType;
 import io.wcm.handler.link.type.MediaLinkType;
 import io.wcm.wcm.commons.util.Template;
 
-import io.wcm.devops.conga.definitions.it.sample.config.AppTemplate;
-
 /**
  * Link handler configuration.
  */
 @Component(service = LinkHandlerConfig.class)
 public class LinkHandlerConfigImpl extends LinkHandlerConfig {
 
-  private static final List<Class<? extends LinkType>> DEFAULT_LINK_TYPES = ImmutableList.<Class<? extends LinkType>>of(
+  private static final List<Class<? extends LinkType>> DEFAULT_LINK_TYPES = List.of(
       InternalLinkType.class,
       InternalCrossContextLinkType.class,
       ExternalLinkType.class,

--- a/bundles/core/src/main/java/io/wcm/devops/conga/definitions/it/sample/config/impl/MediaHandlerConfigImpl.java
+++ b/bundles/core/src/main/java/io/wcm/devops/conga/definitions/it/sample/config/impl/MediaHandlerConfigImpl.java
@@ -6,7 +6,6 @@ import org.jetbrains.annotations.NotNull;
 import org.osgi.service.component.annotations.Component;
 
 import com.day.cq.wcm.api.Page;
-import com.google.common.collect.ImmutableList;
 
 import io.wcm.handler.media.spi.MediaHandlerConfig;
 import io.wcm.handler.media.spi.MediaSource;
@@ -21,7 +20,7 @@ public class MediaHandlerConfigImpl extends MediaHandlerConfig {
 
   static final String DAM_ROOT = "/content/dam/aemdef-it-sample";
 
-  private static final List<Class<? extends MediaSource>> MEDIA_SOURCES = ImmutableList.<Class<? extends MediaSource>>of(
+  private static final List<Class<? extends MediaSource>> MEDIA_SOURCES = List.of(
       DamMediaSource.class,
       InlineMediaSource.class);
 

--- a/bundles/core/src/test/java/io/wcm/devops/conga/definitions/it/sample/components/CustomCarouselTest.java
+++ b/bundles/core/src/test/java/io/wcm/devops/conga/definitions/it/sample/components/CustomCarouselTest.java
@@ -1,10 +1,12 @@
 package io.wcm.devops.conga.definitions.it.sample.components;
 
+import static io.wcm.devops.conga.definitions.it.sample.components.CustomCarousel.NN_SLIDES;
 import static io.wcm.handler.media.MediaNameConstants.PN_MEDIA_REF_STANDARD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.sling.api.resource.Resource;
@@ -13,15 +15,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.day.cq.wcm.api.Page;
-import com.google.common.collect.ImmutableList;
 
+import io.wcm.devops.conga.definitions.it.sample.testcontext.AppAemContext;
 import io.wcm.handler.media.Media;
 import io.wcm.sling.commons.adapter.AdaptTo;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
-
-import static io.wcm.devops.conga.definitions.it.sample.components.CustomCarousel.NN_SLIDES;
-import io.wcm.devops.conga.definitions.it.sample.testcontext.AppAemContext;
 
 @ExtendWith(AemContextExtension.class)
 class CustomCarouselTest {
@@ -55,7 +54,7 @@ class CustomCarouselTest {
         .resource("item2", PN_MEDIA_REF_STANDARD, "/content/dam/slides/slide2.png");
 
     CustomCarousel underTest = AdaptTo.notNull(context.request(), CustomCarousel.class);
-    assertEquals(ImmutableList.of(
+    assertEquals(List.of(
         "/content/dam/slides/slide1.png/_jcr_content/renditions/original./slide1.png",
         "/content/dam/slides/slide2.png/_jcr_content/renditions/original./slide2.png"),
         underTest.getSlideImages().stream()

--- a/config-definition/dispatcher-aem66-run-local.sh
+++ b/config-definition/dispatcher-aem66-run-local.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+function error_log {
+  echo ""
+  echo -e "[\033[0;31mERROR\033[0m] [$(date -R)] $1"
+}
+
+# Build dispatcher config via CONGA
+mvn -Pfast -Dconga.environments=local-aem66 -Dconga.nodes=aem-dispatcher clean package
+
+if [[ $? != 0 ]]; then
+  error_log "Dispatcher config build failed"
+  exit 1
+fi
+
+# Copy Docker compose + image together with generated CONGA configuration
+rm -rf target/docker-dispatcher-aem66
+cp -R src/docker-dispatcher-aem66 target/docker-dispatcher-aem66
+mkdir target/docker-dispatcher-aem66/images/aem-dispatcher-publish/conf
+cp -R target/configuration/local-aem66/aem-dispatcher/*.d target/docker-dispatcher-aem66/images/aem-dispatcher-publish/conf
+
+# Build and start docker container
+docker-compose -f target/docker-dispatcher-aem66/docker-compose.yml build
+
+if [[ $? != 0 ]]; then
+  error_log "docker-compose build failed"
+  exit 1
+fi
+
+docker-compose -f target/docker-dispatcher-aem66/docker-compose.yml up --abort-on-container-exit --exit-code-from aem-dispatcher-publish
+docker-compose -f target/docker-dispatcher-aem66/docker-compose.yml down

--- a/config-definition/pom.xml
+++ b/config-definition/pom.xml
@@ -70,6 +70,23 @@
       <scope>compile</scope>
     </dependency>
 
+    <!-- Context-Aware Configuration -->
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.caconfig.api</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.caconfig.spi</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.caconfig.impl</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/config-definition/src/docker-dispatcher-aem65/docker-compose.yml
+++ b/config-definition/src/docker-dispatcher-aem65/docker-compose.yml
@@ -1,7 +1,6 @@
-version: '2'
 services:
   aem-dispatcher-publish:
     build: images/aem-dispatcher-publish
     container_name: aem-dispatcher-publish
     ports:
-      - "55035:55035"
+      - "5505:5505"

--- a/config-definition/src/docker-dispatcher-aem65/images/aem-dispatcher-publish/Dockerfile
+++ b/config-definition/src/docker-dispatcher-aem65/images/aem-dispatcher-publish/Dockerfile
@@ -1,10 +1,10 @@
 FROM httpd:2.4
 
-ENV DISPATCHER_VERSION 4.3.4
+ENV DISPATCHER_VERSION 4.3.8
 ENV APACHE_LOG_DIR logs
 
-# Also listen to port 55035
-RUN echo 'Listen 55035' >> "${HTTPD_PREFIX}/conf/httpd.conf"
+# Also listen to port 5505
+RUN echo 'Listen 5505' >> "${HTTPD_PREFIX}/conf/httpd.conf"
 
 # Download and unpack dispatcher
 RUN mkdir -p /tmp/dispatcher

--- a/config-definition/src/docker-dispatcher-aem66/docker-compose.yml
+++ b/config-definition/src/docker-dispatcher-aem66/docker-compose.yml
@@ -1,7 +1,6 @@
-version: '2'
 services:
   aem-dispatcher-publish:
     build: images/aem-dispatcher-publish
     container_name: aem-dispatcher-publish
     ports:
-      - "55036:55036"
+      - "5506:5506"

--- a/config-definition/src/docker-dispatcher-aem66/docker-compose.yml
+++ b/config-definition/src/docker-dispatcher-aem66/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '2'
+services:
+  aem-dispatcher-publish:
+    build: images/aem-dispatcher-publish
+    container_name: aem-dispatcher-publish
+    ports:
+      - "55036:55036"

--- a/config-definition/src/docker-dispatcher-aem66/images/aem-dispatcher-publish/Dockerfile
+++ b/config-definition/src/docker-dispatcher-aem66/images/aem-dispatcher-publish/Dockerfile
@@ -1,0 +1,45 @@
+FROM httpd:2.4
+
+ENV DISPATCHER_VERSION 4.3.8
+ENV APACHE_LOG_DIR logs
+
+# Also listen to port 55036
+RUN echo 'Listen 55036' >> "${HTTPD_PREFIX}/conf/httpd.conf"
+
+# Download and unpack dispatcher
+RUN mkdir -p /tmp/dispatcher
+ADD --chown=root:www-data "http://download.macromedia.com/dispatcher/download/dispatcher-apache2.4-linux-x86_64-${DISPATCHER_VERSION}.tar.gz" /tmp/dispatcher/
+RUN cd /tmp/dispatcher && \
+    tar -xzvf "dispatcher-apache2.4-linux-x86_64-${DISPATCHER_VERSION}.tar.gz" && \
+    chown -R root:www-data *
+
+# Install mod_dispatcher
+RUN ln -s "/tmp/dispatcher/dispatcher-apache2.4-${DISPATCHER_VERSION}.so" "${HTTPD_PREFIX}/modules/mod_dispatcher.so" && \
+    sed -i '/#LoadModule info_module modules\/mod_info.so/a LoadModule dispatcher_module modules\/mod_dispatcher.so' "${HTTPD_PREFIX}/conf/httpd.conf" > /dev/null && \
+    sed -i '/<Directory "\/usr\/local\/apache2\/htdocs">/a <IfModule disp_apache2.c> \n\
+    ModMimeUsePathInfo On \n\
+    SetHandler dispatcher-handler \n\
+</IfModule>' "${HTTPD_PREFIX}/conf/httpd.conf" > /dev/null
+
+# Enable mod_include
+RUN sed -i 's/#LoadModule include_module modules\/mod_include.so/LoadModule include_module modules\/mod_include.so/g' "${HTTPD_PREFIX}/conf/httpd.conf" > /dev/null
+
+# Enable mod_rewrite
+RUN sed -i 's/#LoadModule rewrite_module modules\/mod_rewrite.so/LoadModule rewrite_module modules\/mod_rewrite.so/g' "${HTTPD_PREFIX}/conf/httpd.conf" > /dev/null
+
+# Enable mod_deflate
+RUN sed -i 's/#LoadModule deflate_module modules\/mod_deflate.so/LoadModule deflate_module modules\/mod_deflate.so/g' "${HTTPD_PREFIX}/conf/httpd.conf" > /dev/null
+
+# Copy CONGA-generate dispatcher config
+COPY conf/conf.d/* "${HTTPD_PREFIX}/conf.d/"
+COPY conf/dispatcher.d/* "${HTTPD_PREFIX}/dispatcher.d/"
+COPY conf/vhosts.d/* "${HTTPD_PREFIX}/vhosts.d/"
+
+# Include dispatcher.conf in httpd.conf
+RUN echo 'Include conf.d/dispatcher.conf' >> "${HTTPD_PREFIX}/conf/httpd.conf"
+
+# Include vhosts
+RUN echo 'Include vhosts.d/*.conf' >> "${HTTPD_PREFIX}/conf/httpd.conf"
+
+# Fix permissions for dispatcher caching folder
+RUN chown daemon:www-data htdocs

--- a/config-definition/src/docker-dispatcher-aem66/images/aem-dispatcher-publish/Dockerfile
+++ b/config-definition/src/docker-dispatcher-aem66/images/aem-dispatcher-publish/Dockerfile
@@ -3,8 +3,8 @@ FROM httpd:2.4
 ENV DISPATCHER_VERSION 4.3.8
 ENV APACHE_LOG_DIR logs
 
-# Also listen to port 55036
-RUN echo 'Listen 55036' >> "${HTTPD_PREFIX}/conf/httpd.conf"
+# Also listen to port 5506
+RUN echo 'Listen 5506' >> "${HTTPD_PREFIX}/conf/httpd.conf"
 
 # Download and unpack dispatcher
 RUN mkdir -p /tmp/dispatcher

--- a/config-definition/src/main/dev-environments/local-aem65.yaml
+++ b/config-definition/src/main/dev-environments/local-aem65.yaml
@@ -64,7 +64,7 @@ tenants:
     app.rootPath: /content/aemdef-it-sample/tenant1
     httpd:
       serverName: tenant1.aemdef-it-sample-65.localhost
-      serverPort: 55035
+      serverPort: 5505
       rootRedirect.url: /en.html
     sling.mapping.rootPath: ${app.rootPath}
 - tenant: tenant2
@@ -72,7 +72,7 @@ tenants:
     app.rootPath: /content/aemdef-it-sample/tenant2
     httpd:
       serverName: tenant2.aemdef-it-sample-65.localhost
-      serverPort: 55035
+      serverPort: 5505
       rootRedirect.url: /en.html
     sling.mapping.rootPath: ${app.rootPath}
 - tenant: tenant3-no-mapping
@@ -80,5 +80,5 @@ tenants:
     app.rootPath: /content/aemdef-it-sample/tenant3-no-mapping
     httpd:
       serverName: tenant3-no-mapping.aemdef-it-sample-65.localhost
-      serverPort: 55035
+      serverPort: 5505
       rootRedirect.url: ${app.rootPath}/en.html

--- a/config-definition/src/main/dev-environments/local-aem66.yaml
+++ b/config-definition/src/main/dev-environments/local-aem66.yaml
@@ -64,7 +64,7 @@ tenants:
     app.rootPath: /content/aemdef-it-sample/tenant1
     httpd:
       serverName: tenant1.aemdef-it-sample-66.localhost
-      serverPort: 55036
+      serverPort: 5506
       rootRedirect.url: /en.html
     sling.mapping.rootPath: ${app.rootPath}
 - tenant: tenant2
@@ -72,7 +72,7 @@ tenants:
     app.rootPath: /content/aemdef-it-sample/tenant2
     httpd:
       serverName: tenant2.aemdef-it-sample-66.localhost
-      serverPort: 55036
+      serverPort: 5506
       rootRedirect.url: /en.html
     sling.mapping.rootPath: ${app.rootPath}
 - tenant: tenant3-no-mapping
@@ -80,5 +80,5 @@ tenants:
     app.rootPath: /content/aemdef-it-sample/tenant3-no-mapping
     httpd:
       serverName: tenant3-no-mapping.aemdef-it-sample-66.localhost
-      serverPort: 55036
+      serverPort: 5506
       rootRedirect.url: ${app.rootPath}/en.html

--- a/config-definition/src/main/dev-environments/local-aem66.yaml
+++ b/config-definition/src/main/dev-environments/local-aem66.yaml
@@ -1,0 +1,84 @@
+# AEM configuration local AEM 6.6 environment with local dispatcher
+
+nodes:
+
+- node: aem-author
+  roles:
+  - role: aemdef-it-sample-aem-cms
+    variant: aem-author
+  config:
+    replication.author.publishTargets:
+    - name: publish
+      url: ${maven::sling.publish.url}
+      transportUser: admin
+      transportPassword: admin
+
+- node: aem-publish
+  roles:
+  - role: aemdef-it-sample-aem-cms
+    variant: aem-publish
+
+- node: aem-dispatcher
+  roles:
+  - role: aem-dispatcher
+    variant: aem-publish
+  config:
+    dispatcher:
+      cache:
+        rootPath: /var/cache/publish1
+        statFilesLevel: 2
+      renderInstance:
+        host: host.docker.internal
+        port: 45036
+      # Allow access to model.json
+      filter:
+      - _merge_
+      - url: /content(/.*)?
+        extension: json
+        selectors: model
+        type: allow
+
+
+config:
+  contentPackage.group: wcmio-devops-it
+  app:
+    # Default log level for application code
+    logLevel: warn
+    # Whether to deploy conf content with editable template definitions
+    confContent: true
+    # Whether to deploy sample content
+    sampleContent: true
+    # AEM 6.6 deployment
+    aem66: true
+    serverProtocol: http
+    authorSiteUrl: http://localhost:45026
+
+  # Not used for AEM cloud
+  cloudManager.target:
+  - none
+
+
+tenants:
+- tenant: tenant1
+  config:
+    app.rootPath: /content/aemdef-it-sample/tenant1
+    httpd:
+      serverName: tenant1.aemdef-it-sample-66.localhost
+      serverPort: 55036
+      rootRedirect.url: /en.html
+    sling.mapping.rootPath: ${app.rootPath}
+- tenant: tenant2
+  config:
+    app.rootPath: /content/aemdef-it-sample/tenant2
+    httpd:
+      serverName: tenant2.aemdef-it-sample-66.localhost
+      serverPort: 55036
+      rootRedirect.url: /en.html
+    sling.mapping.rootPath: ${app.rootPath}
+- tenant: tenant3-no-mapping
+  config:
+    app.rootPath: /content/aemdef-it-sample/tenant3-no-mapping
+    httpd:
+      serverName: tenant3-no-mapping.aemdef-it-sample-66.localhost
+      serverPort: 55036
+      rootRedirect.url: ${app.rootPath}/en.html

--- a/config-definition/src/main/roles/aemdef-it-sample-aem-cms.yaml
+++ b/config-definition/src/main/roles/aemdef-it-sample-aem-cms.yaml
@@ -23,7 +23,7 @@ files:
 # AEM Core WCM components
 - url: mvn:com.adobe.cq/core.wcm.components.all//zip
   dir: packages
-  condition: ${app.aem65}
+  condition: ${app.aem65 || app.aem66}
 
 # Include URL handler in Sling Rewriter configuration
 - file: aemdef-it-sample-aem-cms-rewriter-config.json
@@ -47,7 +47,7 @@ files:
   dir: packages
 - url: mvn:io.wcm.devops.conga.definitions.it/io.wcm.devops.conga.definitions.it.sample.core//zip/content
   dir: packages
-  condition: ${!(app.aem65)}
+  condition: ${!(app.aem65 || app.aem66)}
 
 # Application conf content package
 - url: mvn:io.wcm.devops.conga.definitions.it/io.wcm.devops.conga.definitions.it.sample.conf-content//zip

--- a/config-definition/src/main/roles/aemdef-it-sample-aem-cms.yaml
+++ b/config-definition/src/main/roles/aemdef-it-sample-aem-cms.yaml
@@ -12,9 +12,8 @@ templateDir: aemdef-it-sample-aem-cms
 
 files:
 
-
 # AEM Service Pack
-- url: mvn:adobe.binary.aem.65.servicepack/aem-service-pkg/6.5.22.0/zip
+- url: mvn:adobe.binary.aem.65.servicepack/aem-service-pkg/6.5.24.0/zip
   dir: packages
   modelOptions:
     delayAfterInstallSec: 30
@@ -24,6 +23,17 @@ files:
 - url: mvn:com.adobe.cq/core.wcm.components.all//zip
   dir: packages
   condition: ${app.aem65 || app.aem66}
+
+# Context-Aware Configuration
+- url: mvn:org.apache.sling/org.apache.sling.caconfig.api
+  dir: bundles
+  condition: ${app.aem65}
+- url: mvn:org.apache.sling/org.apache.sling.caconfig.spi
+  dir: bundles
+  condition: ${app.aem65}
+- url: mvn:org.apache.sling/org.apache.sling.caconfig.impl
+  dir: bundles
+  condition: ${app.aem65}
 
 # Include URL handler in Sling Rewriter configuration
 - file: aemdef-it-sample-aem-cms-rewriter-config.json

--- a/config-definition/src/main/roles/aemdef-it-sample-aem-cms.yaml
+++ b/config-definition/src/main/roles/aemdef-it-sample-aem-cms.yaml
@@ -103,6 +103,7 @@ config:
     confContent: true
     sampleContent: false
     aem65: false
+    aem66: false
     rootPath:
     serverProtocol: https
     authorSiteUrl:

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -198,6 +198,23 @@
         <version>2.0.0</version>
       </dependency>
 
+      <!-- Context-Aware Configuration -->
+      <dependency>
+        <groupId>org.apache.sling</groupId>
+        <artifactId>org.apache.sling.caconfig.api</artifactId>
+        <version>1.3.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.sling</groupId>
+        <artifactId>org.apache.sling.caconfig.spi</artifactId>
+        <version>1.4.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.sling</groupId>
+        <artifactId>org.apache.sling.caconfig.impl</artifactId>
+        <version>1.7.2</version>
+      </dependency>
+
       <!-- AEM dependencies -->
       <dependency>
         <groupId>io.wcm.maven</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -153,7 +153,7 @@
       <dependency>
         <groupId>io.wcm.devops.conga.definitions</groupId>
         <artifactId>io.wcm.devops.conga.definitions.aem</artifactId>
-        <version>2.1.2</version>
+        <version>2.1.3-SNAPSHOT</version>
       </dependency>
 
       <!-- wcm.io Testing -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -24,7 +24,6 @@
     <!-- AEM instance parameters -->
     <sling.url>http://localhost:4502</sling.url>
     <sling.publish.url>http://localhost:4503</sling.publish.url>
-    <deploy.aem65>false</deploy.aem65>
 
     <!-- Set to 'enabled' to activate org.eclipse.jdt.core.compiler.annotation.nullanalysis feature in eclipse settings -->
     <eclipse.settings.nullanalysis>enabled</eclipse.settings.nullanalysis>
@@ -84,7 +83,7 @@
       <dependency>
         <groupId>io.wcm</groupId>
         <artifactId>io.wcm.caconfig.extensions</artifactId>
-        <version>1.8.8</version>
+        <version>1.11.0</version>
       </dependency>
       <dependency>
         <groupId>io.wcm</groupId>
@@ -268,6 +267,25 @@
         <!-- AEM instance parameters -->
         <sling.url>http://localhost:45025</sling.url>
         <sling.publish.url>http://localhost:45035</sling.publish.url>
+      </properties>
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>io.wcm</groupId>
+            <artifactId>io.wcm.caconfig.extensions</artifactId>
+            <version>1.8.8</version>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+    </profile>
+
+    <!-- Deployment to AEM 6.6 -->
+    <profile>
+      <id>aem66</id>
+      <properties>
+        <!-- AEM instance parameters -->
+        <sling.url>http://localhost:45026</sling.url>
+        <sling.publish.url>http://localhost:45036</sling.publish.url>
       </properties>
     </profile>
 

--- a/testing/dispatcher-integration/README.md
+++ b/testing/dispatcher-integration/README.md
@@ -7,8 +7,14 @@ Dispatcher Integration Tests
 mvn clean verify -Dintegrationtests.skip=false
 ```
 
-### Run integration tests for AEMaaCS
+### Run integration tests for AEM 6.5
 
 ```bash
 mvn clean verify -Dintegrationtests.skip=false -Paem65
+```
+
+### Run integration tests for AEM 6.6
+
+```bash
+mvn clean verify -Dintegrationtests.skip=false -Paem66
 ```

--- a/testing/dispatcher-integration/pom.xml
+++ b/testing/dispatcher-integration/pom.xml
@@ -63,17 +63,17 @@
     <profile>
       <id>aem65</id>
       <properties>
-        <tenant1.url>http://tenant1.aemdef-it-sample-65.localhost:55035</tenant1.url>
-        <tenant2.url>http://tenant2.aemdef-it-sample-65.localhost:55035</tenant2.url>
-        <tenant3.url>http://tenant3-no-mapping.aemdef-it-sample-65.localhost:55035</tenant3.url>
+        <tenant1.url>http://tenant1.aemdef-it-sample-65.localhost:5505</tenant1.url>
+        <tenant2.url>http://tenant2.aemdef-it-sample-65.localhost:5505</tenant2.url>
+        <tenant3.url>http://tenant3-no-mapping.aemdef-it-sample-65.localhost:5505</tenant3.url>
       </properties>
     </profile>
     <profile>
       <id>aem66</id>
       <properties>
-        <tenant1.url>http://tenant1.aemdef-it-sample-66.localhost:55036</tenant1.url>
-        <tenant2.url>http://tenant2.aemdef-it-sample-66.localhost:55036</tenant2.url>
-        <tenant3.url>http://tenant3-no-mapping.aemdef-it-sample-66.localhost:55036</tenant3.url>
+        <tenant1.url>http://tenant1.aemdef-it-sample-66.localhost:5506</tenant1.url>
+        <tenant2.url>http://tenant2.aemdef-it-sample-66.localhost:5506</tenant2.url>
+        <tenant3.url>http://tenant3-no-mapping.aemdef-it-sample-66.localhost:5506</tenant3.url>
       </properties>
     </profile>
   </profiles>

--- a/testing/dispatcher-integration/pom.xml
+++ b/testing/dispatcher-integration/pom.xml
@@ -68,6 +68,14 @@
         <tenant3.url>http://tenant3-no-mapping.aemdef-it-sample-65.localhost:55035</tenant3.url>
       </properties>
     </profile>
+    <profile>
+      <id>aem66</id>
+      <properties>
+        <tenant1.url>http://tenant1.aemdef-it-sample-66.localhost:55036</tenant1.url>
+        <tenant2.url>http://tenant2.aemdef-it-sample-66.localhost:55036</tenant2.url>
+        <tenant3.url>http://tenant3-no-mapping.aemdef-it-sample-66.localhost:55036</tenant3.url>
+      </properties>
+    </profile>
   </profiles>
 
 </project>

--- a/testing/dispatcher-integration/run-integration-tests-aem66.sh
+++ b/testing/dispatcher-integration/run-integration-tests-aem66.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [[ $0 == *":\\"* ]]; then
+  DISPLAY_PAUSE_MESSAGE=true
+fi
+
+mvn clean verify -Dintegrationtests.skip=false -Paem66
+
+if [ "$DISPLAY_PAUSE_MESSAGE" = true ]; then
+  echo ""
+  read -n1 -r -p "Press any key to continue..."
+fi


### PR DESCRIPTION
also:
* git rid of guava dependency
* switch to latest wcm.io caconfig extensions, updating sling caconfig for AEM 6.5
* change range of dispatcher port numbers to avoid reserved ranges on windows
* update dispatcher dependency